### PR TITLE
Add filenameRelative to opts to support AMD module names

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ module.exports = function (opts) {
 		try {
 			var fileOpts = objectAssign({}, opts, {
 				filename: file.path,
+				filenameRelative: file.relative,
 				sourceMap: !!file.sourceMap
 			});
 


### PR DESCRIPTION
In light of 6to5/6to5/pull/176 it would be nice to have relative filename support so that AMD/UMD modules can have customized generated module names right from the gulp workflow.
