### PR TITLE
Improve `error.toString()`

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ module.exports = function (opts) {
 			file.contents = new Buffer(res.code);
 			this.push(file);
 		} catch (err) {
-			this.emit('error', new gutil.PluginError('gulp-babel', err, {fileName: file.path}));
+			this.emit('error', new gutil.PluginError('gulp-babel', err, {fileName: file.path, showProperties: false}));
 		}
 
 		cb();


### PR DESCRIPTION
Cleaned up the `error.toString()` a bit.

Before this PR:

![image](https://cloud.githubusercontent.com/assets/2090712/6772119/d2343160-d0d3-11e4-9dd0-cc81b6af9853.png)

After:

![image](https://cloud.githubusercontent.com/assets/2090712/6772123/ebc7b69c-d0d3-11e4-9443-c555087280dc.png)
