### PR TITLE
add file metadata from babel transform.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = function (opts) {
 
 			file.contents = new Buffer(res.code);
 			file.path = replaceExt(file.path, '.js');
+			file.babel = res.metadata;
 			this.push(file);
 		} catch (err) {
 			this.emit('error', new gutil.PluginError('gulp-babel', err, {fileName: file.path, showProperties: false}));

--- a/readme.md
+++ b/readme.md
@@ -55,6 +55,30 @@ gulp.task('default', function () {
 });
 ```
 
+## Babel Metadata
+
+The files that are emitted from this are annotated with a `babel` property, which
+contains the metadata from the `babel.transform()` call. The metadata properties are listed
+[here](http://babeljs.io/docs/advanced/external-helpers/#selective-builds).
+
+example:
+```js
+var gulp = require('gulp');
+var babel = require('gulp-babel');
+var through = require('through2');
+
+function logFileHelpers () {
+	return through.obj(function (file, enc, done) {
+		console.log(file.babel.usedHelpers);
+	});
+}
+
+gulp.task('default', function () {
+	return gulp.src('src/**/*.js')
+		.pipe(babel())
+		.pipe(logFileHelpers);
+})
+```
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -49,3 +49,22 @@ it('should generate source maps', function (cb) {
 
 	init.end();
 });
+
+it('should list used helpers in file.babel', function (cb) {
+	var stream = to5();
+
+	stream.on('data', function (file) {
+		assert.deepEqual(file.babel.usedHelpers, ['class-call-check']);
+	});
+
+	stream.on('end', cb);
+
+	stream.write(new gutil.File({
+		cwd: __dirname,
+		base: __dirname + '/fixture',
+		path: __dirname + '/fixture/fixture.es6',
+		contents: new Buffer('class MyClass {};')
+	}));
+
+	stream.end();
+});


### PR DESCRIPTION
I would like to use this metadata from the babel transform step to aggregate the used helpers to prevent many copies of the same helper in my code, but currently `gulp-babel` does not pass through this metadata. 