### PR TITLE
chore: update babel-core to 6.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "6to5"
   ],
   "dependencies": {
-    "babel-core": "^5.8.19",
+    "babel-core": "^6.0.2",
     "gulp-util": "^3.0.0",
     "object-assign": "^4.0.1",
     "replace-ext": "0.0.1",
@@ -45,6 +45,9 @@
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {
+    "babel-plugin-transform-es2015-arrow-functions": "^6.0.2",
+    "babel-plugin-transform-es2015-block-scoping": "^6.0.9",
+    "babel-plugin-transform-es2015-classes": "^6.0.8",
     "gulp-sourcemaps": "^1.1.1",
     "mocha": "*",
     "xo": "*"

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 ## Install
 
 ```
-$ npm install --save-dev gulp-babel
+$ npm install --save-dev gulp-babel babel-preset-es2015
 ```
 
 
@@ -20,7 +20,9 @@ var babel = require('gulp-babel');
 
 gulp.task('default', function () {
 	return gulp.src('src/app.js')
-		.pipe(babel())
+		.pipe(babel({
+			presets: ['babel-preset-es2015']
+		}))
 		.pipe(gulp.dest('dist'));
 });
 ```
@@ -59,7 +61,7 @@ gulp.task('default', function () {
 ## Babel Metadata
 
 Files in the stream are annotated with a `babel` property, which
-contains the [metadata](http://babeljs.io/docs/advanced/external-helpers/#selective-builds) from `babel.transform()`.
+contains the metadata from `babel.transform()`.
 
 #### Example
 
@@ -84,15 +86,21 @@ gulp.task('default', function () {
 
 ## Runtime
 
-If you are attempting to use features such as generators, you will need to pass `{ optional: ['runtime'] }` to include the babel runtime. Otherwise you will receive the error: `regeneratorRuntime is not defined`.
+If you are attempting to use features such as generators, you will need to add `transform-runtime` as plugin to include the babel runtime. Otherwise you will receive the error: `regeneratorRuntime is not defined`.
 
+Install the runtime:
+```
+npm install --save-dev babel-plugin-transform-runtime
+```
+
+Use it as plugin:
 ```js
 var gulp = require('gulp');
 var babel = require('gulp-babel');
 
 gulp.task('default', function () {
 	return gulp.src('src/app.js')
-		.pipe(babel({ optional: ['runtime'] }))
+		.pipe(babel({ plugins: ['transform-runtime'] }))
 		.pipe(gulp.dest('dist'));
 });
 ```

--- a/readme.md
+++ b/readme.md
@@ -79,7 +79,9 @@ function logFileHelpers() {
 
 gulp.task('default', function () {
 	return gulp.src('src/**/*.js')
-		.pipe(babel())
+		.pipe(babel({
+			presets: ['babel-preset-es2015']
+		}))
 		.pipe(logFileHelpers);
 })
 ```

--- a/test.js
+++ b/test.js
@@ -6,7 +6,9 @@ var sourceMaps = require('gulp-sourcemaps');
 var babel = require('./');
 
 it('should transpile with Babel', function (cb) {
-	var stream = babel();
+	var stream = babel({
+		plugins: ['transform-es2015-block-scoping']
+	});
 
 	stream.on('data', function (file) {
 		assert(/var foo/.test(file.contents.toString()), file.contents.toString());
@@ -29,7 +31,9 @@ it('should generate source maps', function (cb) {
 	var init = sourceMaps.init();
 	var write = sourceMaps.write();
 	init
-		.pipe(babel())
+		.pipe(babel({
+			plugins: ['transform-es2015-arrow-functions']
+		}))
 		.pipe(write);
 
 	write.on('data', function (file) {
@@ -53,10 +57,12 @@ it('should generate source maps', function (cb) {
 });
 
 it('should list used helpers in file.babel', function (cb) {
-	var stream = babel();
+	var stream = babel({
+		plugins: ['transform-es2015-classes']
+	});
 
 	stream.on('data', function (file) {
-		assert.deepEqual(file.babel.usedHelpers, ['class-call-check']);
+		assert.deepEqual(file.babel.usedHelpers, ['classCallCheck']);
 	});
 
 	stream.on('end', cb);


### PR DESCRIPTION
This

* Updates babel-core to `v6.0.2`
* Adapts the tests to work with the new configuration
* Adds the required babel-plugin-* modules as `devDependencies`