### PR TITLE
Don't rename ignored files

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,10 @@ module.exports = function (opts) {
 				applySourceMap(file, res.map);
 			}
 
-			file.contents = new Buffer(res.code);
-			file.path = replaceExt(file.path, '.js');
+			if (!res.ignored) {
+				file.contents = new Buffer(res.code);
+				file.path = replaceExt(file.path, '.js');
+			}
 			file.babel = res.metadata;
 
 			this.push(file);

--- a/test.js
+++ b/test.js
@@ -76,3 +76,24 @@ it('should list used helpers in file.babel', function (cb) {
 
 	stream.end();
 });
+
+it('should not rename ignored files', function (cb) {
+	var stream = babel({
+		ignore: /fixture/
+	});
+
+	var inputFile = {
+		cwd: __dirname
+	};
+	inputFile.base = path.join(inputFile.cwd, 'fixture');
+	inputFile.basename = 'fixture.jsx';
+	inputFile.path = path.join(inputFile.base, inputFile.basename);
+	inputFile.contents = new Buffer(';');
+
+	stream
+		.on('data', function (file) {
+			assert.equal(file.relative, inputFile.basename);
+		})
+		.on('end', cb)
+		.end(new gutil.File(inputFile));
+});


### PR DESCRIPTION
I don't think this should rename files that are ignored by Babel. A simple example use case is globbing in JS and JSON files where you want the JS to be compiled and the JSON to just be passed through and copied to dest.

```js
gulp.src("*.{js,json}")
  .pipe(babel({ignore: /\.json$/}))
  .pipe(gulp.dest("whatever"));
```

It's not the point, but this also saves allocating a new buffer for unchanged files.