### PR TITLE
Fix sourcemap's bug for files in nested folders. Closes #54

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,9 @@ module.exports = function (opts) {
 			var fileOpts = objectAssign({}, opts, {
 				filename: file.path,
 				filenameRelative: file.relative,
-				sourceMap: Boolean(file.sourceMap)
+				sourceMap: Boolean(file.sourceMap),
+				sourceFileName: file.relative,
+				sourceMapTarget: file.relative
 			});
 
 			var res = babel.transform(file.contents.toString(), fileOpts);

--- a/test.js
+++ b/test.js
@@ -56,6 +56,35 @@ it('should generate source maps', function (cb) {
 	init.end();
 });
 
+it('should generate source maps for file in nested folder', function (cb) {
+	var init = sourceMaps.init();
+	var write = sourceMaps.write();
+	init
+		.pipe(babel({
+			plugins: ['transform-es2015-arrow-functions']
+		}))
+		.pipe(write);
+
+	write.on('data', function (file) {
+		assert.deepEqual(file.sourceMap.sources, ['nested/fixture.es6']);
+		assert.strictEqual(file.sourceMap.file, 'nested/fixture.js');
+		var contents = file.contents.toString();
+		assert(/function/.test(contents));
+		assert(/sourceMappingURL/.test(contents));
+		cb();
+	});
+
+	init.write(new gutil.File({
+		cwd: __dirname,
+		base: path.join(__dirname, 'fixture'),
+		path: path.join(__dirname, 'fixture/nested/fixture.es6'),
+		contents: new Buffer('[].map(v => v + 1)'),
+		sourceMap: ''
+	}));
+
+	init.end();
+});
+
 it('should list used helpers in file.babel', function (cb) {
 	var stream = babel({
 		plugins: ['transform-es2015-classes']


### PR DESCRIPTION
## Before fix:
<img width="178" alt="screen shot 2015-11-22 at 14 06 05" src="https://cloud.githubusercontent.com/assets/6995947/11323610/3d82a3a2-9127-11e5-889a-fd04545b442a.png">

## After fix:
<img width="179" alt="screen shot 2015-11-22 at 15 29 45" src="https://cloud.githubusercontent.com/assets/6995947/11323811/5446798a-912f-11e5-80cc-931975871261.png">


## Simple gulp task to reproduce it:
```
const gulp        = require('gulp');
const babel       = require('gulp-babel');
const sourcemaps  = require('gulp-sourcemaps');

gulp.task('default', () => {
  return gulp.src('src/**/*.js')
    .pipe( sourcemaps.init() )
    .pipe( babel({ presets: ['es2015'] }) )
    .pipe( sourcemaps.write() )
    .pipe( gulp.dest('dest') )
  ;
});
```

## Folders structure of this example:
```
src
├── nested
│   ├── nested
│   │   └── source3.js
│   └── source2.js
└── source1.js
```

I already pushed fix for this problem to babel-core, but now I understood how we could fix it here.

## closes #54 