### PR TITLE
Added support for files named like name.js.ext

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var applySourceMap = require('vinyl-sourcemaps-apply');
 var objectAssign = require('object-assign');
 var replaceExt = require('replace-ext');
 var babel = require('babel-core');
+var path = require('path');
 
 module.exports = function (opts) {
 	opts = opts || {};
@@ -32,13 +33,19 @@ module.exports = function (opts) {
 			var res = babel.transform(file.contents.toString(), fileOpts);
 
 			if (file.sourceMap && res.map) {
-				res.map.file = replaceExt(res.map.file, '.js');
+				res.map.file = replaceExt(res.map.file, '');
+				if (path.extname(res.map.file) !== '.js') {
+					res.map.file = replaceExt(res.map.file, '.js');
+				}
 				applySourceMap(file, res.map);
 			}
 
 			if (!res.ignored) {
 				file.contents = new Buffer(res.code);
-				file.path = replaceExt(file.path, '.js');
+				file.path = replaceExt(file.path, '');
+				if (path.extname(file.path) !== '.js') {
+					file.path = replaceExt(file.path, '.js');
+				}
 			}
 
 			file.babel = res.metadata;

--- a/test.js
+++ b/test.js
@@ -56,6 +56,35 @@ it('should generate source maps', function (cb) {
 	init.end();
 });
 
+it('should generate source maps for flow files', function (cb) {
+	var init = sourceMaps.init();
+	var write = sourceMaps.write();
+	init
+		.pipe(babel({
+			plugins: ['transform-es2015-arrow-functions']
+		}))
+		.pipe(write);
+
+	write.on('data', function (file) {
+		assert.deepEqual(file.sourceMap.sources, ['fixture.js.flow']);
+		assert.strictEqual(file.sourceMap.file, 'fixture.js');
+		var contents = file.contents.toString();
+		assert(/function/.test(contents));
+		assert(/sourceMappingURL/.test(contents));
+		cb();
+	});
+
+	init.write(new gutil.File({
+		cwd: __dirname,
+		base: path.join(__dirname, 'fixture'),
+		path: path.join(__dirname, 'fixture/fixture.js.flow'),
+		contents: new Buffer('[].map(v => v + 1)'),
+		sourceMap: ''
+	}));
+
+	init.end();
+});
+
 it('should generate source maps for file in nested folder', function (cb) {
 	var init = sourceMaps.init();
 	var write = sourceMaps.write();


### PR DESCRIPTION
**problem**
A sourcefile named e.g. name.js.flow will be transpiled into a file named name.js.js.

**reason**
Files that end with .flow are now treated specially. They are the preferred provider of modules. You would therefore normally have a file name.js that is the transpiled file and a file name.js.flow that is the orignal source file. The file name.js.flow will be used by flow for type resolution. If you transpile from name.js.flow the file can also be used fro debugging.

**solution**
Creates the filename by first removing the extension. If the file then have a .js extension nothing is done otherwise a .js is addes just like before.