### PR TITLE
Don't add '.js' extension if the source file doesn't have an extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,19 @@
 'use strict';
+var path = require('path');
 var gutil = require('gulp-util');
 var through = require('through2');
 var applySourceMap = require('vinyl-sourcemaps-apply');
 var objectAssign = require('object-assign');
 var replaceExt = require('replace-ext');
 var babel = require('babel-core');
+
+function replaceExtension(filepath) {
+	if (path.extname(filepath)) {
+		return replaceExt(filepath, '.js');
+	}
+
+	return filepath;
+}
 
 module.exports = function (opts) {
 	opts = opts || {};
@@ -32,13 +41,13 @@ module.exports = function (opts) {
 			var res = babel.transform(file.contents.toString(), fileOpts);
 
 			if (file.sourceMap && res.map) {
-				res.map.file = replaceExt(res.map.file, '.js');
+				res.map.file = replaceExtension(res.map.file);
 				applySourceMap(file, res.map);
 			}
 
 			if (!res.ignored) {
 				file.contents = new Buffer(res.code);
-				file.path = replaceExt(file.path, '.js');
+				file.path = replaceExtension(file.path);
 			}
 
 			file.babel = res.metadata;

--- a/test.js
+++ b/test.js
@@ -127,3 +127,23 @@ it('should not rename ignored files', function (cb) {
 		.on('end', cb)
 		.end(new gutil.File(inputFile));
 });
+
+it('should not rename files without an extension', function (cb) {
+	var stream = babel();
+
+	var inputFile = {
+		cwd: __dirname
+	};
+
+	inputFile.base = path.join(inputFile.cwd, 'bin');
+	inputFile.basename = 'app';
+	inputFile.path = path.join(inputFile.base, inputFile.basename);
+	inputFile.contents = new Buffer(';');
+
+	stream
+		.on('data', function (file) {
+			assert.equal(file.relative, inputFile.basename);
+		})
+		.on('end', cb)
+		.end(new gutil.File(inputFile));
+});


### PR DESCRIPTION
Hello!

I have in my current project a `bin` folder containing executable files without any extension, and I ran into the issue where these files were renamed with a `.js` extension after going through gulp-babel when I wished they could remain extensionless.

I've made a quick change to fix this but, as it causes a change of behaviour, this might possibly break for some users that relied on this feature for their executable files.

To keep backward compatibility, a new option could be added, possibly accepting globs as values, that would allow to filter which files are to be renamed to `.js`, and that would come with a default value preserving the current behaviour. I could have modified the `opts` parameter in this purpose but didn't dare doing so since it should remain dedicated to Babel but maybe adding a second parameter to gulp-babel could do?

Let me know!


Kind regards.
