### PR TITLE
Update babel-core and babel-preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "babel",
     "transpiler",
     "es2015",
+    "es2016",
+    "es2017",
     "rewriting",
     "transformation",
     "syntax",
@@ -32,7 +34,7 @@
     "compiler"
   ],
   "dependencies": {
-    "babel-core": "^6.0.2",
+    "babel-core": "^6.23.1",
     "gulp-util": "^3.0.0",
     "object-assign": "^4.0.1",
     "replace-ext": "0.0.1",

--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 ## Install
 
 ```
-$ npm install --save-dev gulp-babel babel-preset-es2015
+$ npm install --save-dev gulp-babel babel-preset-env
 ```
 
 
@@ -21,7 +21,7 @@ const babel = require('gulp-babel');
 gulp.task('default', () =>
 	gulp.src('src/app.js')
 		.pipe(babel({
-			presets: ['es2015']
+			presets: ['env']
 		}))
 		.pipe(gulp.dest('dist'))
 );
@@ -51,7 +51,7 @@ gulp.task('default', () =>
 	gulp.src('src/**/*.js')
 		.pipe(sourcemaps.init())
 		.pipe(babel({
-			presets: ['es2015']
+			presets: ['env']
 		}))
 		.pipe(concat('all.js'))
 		.pipe(sourcemaps.write('.'))
@@ -81,7 +81,7 @@ function logFileHelpers() {
 gulp.task('default', () =>
 	gulp.src('src/**/*.js')
 		.pipe(babel({
-			presets: ['es2015']
+			presets: ['env']
 		}))
 		.pipe(logFileHelpers())
 )


### PR DESCRIPTION
Updated `babel-core` to the latest.
According to [this tweet](https://twitter.com/left_pad/status/837443603379204096) it is recommended to use `babel-preset-env` instead of `preset-2015`