### PR TITLE
Migrate away from gulp-util

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 'use strict';
 const path = require('path');
-const gutil = require('gulp-util');
+const PluginError = require('plugin-error');
 const through = require('through2');
 const applySourceMap = require('vinyl-sourcemaps-apply');
 const replaceExt = require('replace-ext');
@@ -20,7 +20,7 @@ module.exports = function (opts) {
 		}
 
 		if (file.isStream()) {
-			cb(new gutil.PluginError('gulp-babel', 'Streaming not supported'));
+			cb(new PluginError('gulp-babel', 'Streaming not supported'));
 			return;
 		}
 
@@ -51,7 +51,7 @@ module.exports = function (opts) {
 
 			this.push(file);
 		} catch (err) {
-			this.emit('error', new gutil.PluginError('gulp-babel', err, {
+			this.emit('error', new PluginError('gulp-babel', err, {
 				fileName: file.path,
 				showProperties: false
 			}));

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "compiler"
   ],
   "dependencies": {
-    "gulp-util": "^3.0.0",
-    "replace-ext": "0.0.1",
+    "plugin-error": "^0.1.2",
+    "replace-ext": "^1.0.0",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
@@ -49,6 +49,7 @@
     "@babel/plugin-transform-classes": "7.0.0-beta.5",
     "gulp-sourcemaps": "^1.1.1",
     "mocha": "*",
+    "vinyl": "^2.1.0",
     "xo": "*"
   },
   "xo": {

--- a/test.js
+++ b/test.js
@@ -1,7 +1,7 @@
 'use strict';
 const path = require('path');
 const assert = require('assert');
-const gutil = require('gulp-util');
+const File = require('vinyl');
 const sourceMaps = require('gulp-sourcemaps');
 const babel = require('./');
 
@@ -17,7 +17,7 @@ it('should transpile with Babel', cb => {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new File({
 		cwd: __dirname,
 		base: path.join(__dirname, 'fixture'),
 		path: path.join(__dirname, 'fixture/fixture.jsx'),
@@ -45,7 +45,7 @@ it('should generate source maps', cb => {
 		cb();
 	});
 
-	init.write(new gutil.File({
+	init.write(new File({
 		cwd: __dirname,
 		base: path.join(__dirname, 'fixture'),
 		path: path.join(__dirname, 'fixture/fixture.es2015'),
@@ -74,7 +74,7 @@ it('should generate source maps for file in nested folder', cb => {
 		cb();
 	});
 
-	init.write(new gutil.File({
+	init.write(new File({
 		cwd: __dirname,
 		base: path.join(__dirname, 'fixture'),
 		path: path.join(__dirname, 'fixture/nested/fixture.es2015'),
@@ -100,7 +100,7 @@ it('should pass the result of transform().metadata in file.babel', cb => {
 
 	stream.on('end', cb);
 
-	stream.write(new gutil.File({
+	stream.write(new File({
 		cwd: __dirname,
 		base: path.join(__dirname, 'fixture'),
 		path: path.join(__dirname, 'fixture/fixture.js'),
@@ -129,7 +129,7 @@ it('should not rename ignored files', cb => {
 			assert.equal(file.relative, inputFile.basename);
 		})
 		.on('end', cb)
-		.end(new gutil.File(inputFile));
+		.end(new File(inputFile));
 });
 
 it('should not rename files without an extension', cb => {
@@ -149,5 +149,5 @@ it('should not rename files without an extension', cb => {
 			assert.equal(file.relative, inputFile.basename);
 		})
 		.on('end', cb)
-		.end(new gutil.File(inputFile));
+		.end(new File(inputFile));
 });


### PR DESCRIPTION
gulp-util is deprecated and is gigantic. This reduces size of package download and fixes some out-of-date dependency problems.