### PR TITLE
v7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-babel",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Use next generation JavaScript, today",
   "license": "MIT",
   "repository": "babel/gulp-babel",


### PR DESCRIPTION
- **[Fix]** Drop dependency on `gulp-util` (https://github.com/babel/gulp-babel/commit/dcd652e3b6005bc68ee97e41df07544bcb6c4885)

Backport of #137 following https://github.com/babel/gulp-babel/pull/137#issuecomment-359974112