### PR TITLE
v8.0.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Next
+# 8.0.0-beta.1 (2017-01-26)
 
 - **[Fix]** Drop dependency on deprecated `gulp-util` ([#137](https://github.com/babel/gulp-babel/pull/137))
 - **[Chore]** Update repository: add `CHANGELOG.md`, update `.gitignore`, license year, update dependencies,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-babel",
-  "version": "8.0.0-beta.0",
+  "version": "8.0.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-babel",
-  "version": "8.0.0-beta.0",
+  "version": "8.0.0-beta.1",
   "description": "Use next generation JavaScript, today",
   "license": "MIT",
   "repository": "babel/gulp-babel",


### PR DESCRIPTION
- **[Fix]** Drop dependency on deprecated `gulp-util` ([#137](https://github.com/babel/gulp-babel/pull/137))
- **[Chore]** Update repository: add `CHANGELOG.md`, update `.gitignore`, license year, update dependencies, add lock files, add _npm_ badge, mention `gulp-babel@next`.