### PR TITLE
Fix for `sourceMapTarget` removal in Babel v7.0.0-beta.41

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,15 +29,14 @@ module.exports = function (opts) {
 				filename: file.path,
 				filenameRelative: file.relative,
 				sourceMap: Boolean(file.sourceMap),
-				sourceFileName: file.relative,
-				sourceMapTarget: file.relative
+				sourceFileName: file.relative
 			});
 
 			const res = babel.transform(file.contents.toString(), fileOpts);
 
 			if (res !== null) {
 				if (file.sourceMap && res.map) {
-					res.map.file = replaceExtension(res.map.file);
+					res.map.file = replaceExtension(file.relative);
 					applySourceMap(file, res.map);
 				}
 


### PR DESCRIPTION
Update for https://github.com/babel/babel/releases/tag/v7.0.0-beta.41