### PR TITLE
option for turn off source maps applying

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ gulp.task('default', () =>
 );
 ```
 
+Example with option for switch off source map applying. (pass false as 2nd parameter after babel options)
+
+```js
+const gulp = require('gulp');
+const sourcemaps = require('gulp-sourcemaps');
+const babel = require('gulp-babel');
+const concat = require('gulp-concat');
+
+gulp.task('default', () =>
+	gulp.src('src/**/*.js')
+		.pipe(sourcemaps.init())
+		.pipe(babel({
+			presets: ['@babel/preset-env']
+		}, false))
+		.pipe(concat('all.js'))
+		.pipe(sourcemaps.write('.'))
+		.pipe(gulp.dest('dist'))
+);
+```
+
 
 ## Babel Metadata
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function replaceExtension(fp) {
 	return path.extname(fp) ? replaceExt(fp, '.js') : fp;
 }
 
-module.exports = function (opts) {
+module.exports = function (opts, applySourceMaps = true) {
 	opts = opts || {};
 
 	return through.obj(function (file, enc, cb) {
@@ -44,7 +44,11 @@ module.exports = function (opts) {
 			if (res) {
 				if (file.sourceMap && res.map) {
 					res.map.file = replaceExtension(file.relative);
-					applySourceMap(file, res.map);
+					if (applySourceMaps) {
+						applySourceMap(file, res.map);
+					} else {
+						file.sourceMap = res.map;
+					}
 				}
 
 				file.contents = Buffer.from(res.code);


### PR DESCRIPTION
Added ability to disable source map applying in favor of simple replacement with maps generated by babel.
That fix mightly can resolve problems #108 and #159